### PR TITLE
Implements the requirer side of the n2 relation interface

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,12 +1,4 @@
 options:
-  amf-hostname:
-    type: string
-    default: "amf"
-    description: AMF hostname
-  amf-port:
-    type: int
-    default: 38412
-    description: AMF port
   gnb-ip-address:
     type: string
     default: "192.168.251.5/24"

--- a/lib/charms/sdcore_amf/v0/fiveg_n2.py
+++ b/lib/charms/sdcore_amf/v0/fiveg_n2.py
@@ -1,0 +1,325 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+"""Library for the `fiveg_n2` relation.
+
+This library contains the Requires and Provides classes for handling the `fiveg_n2`
+interface.
+
+The purpose of this library is to relate a charm claiming
+to be able to provide or consume information on connectivity to the N2 plane.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.sdcore_amf.v0.fiveg_n2
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- pydantic
+- pytest-interface-tester
+
+### Requirer charm
+The requirer charm is the one requiring the N2 information.
+
+Example:
+```python
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from charms.sdcore_amf.v0.fiveg_n2 import N2InformationAvailableEvent, N2Requires
+
+logger = logging.getLogger(__name__)
+
+
+class DummyFivegN2Requires(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.n2_requirer = N2Requires(self, "fiveg-n2")
+        self.framework.observe(
+            self.n2_requirer.on.n2_information_available, self._on_n2_information_available
+        )
+
+    def _on_n2_information_available(self, event: N2InformationAvailableEvent):
+        amf_ip_address = event.amf_ip_address
+        amf_hostname = event.amf_hostname
+        amf_port = event.amf_port
+        <do something with the amf IP, hostname and port>
+
+
+if __name__ == "__main__":
+    main(DummyFivegN2Requires)
+```
+
+### Provider charm
+The provider charm is the one providing the information about the N2 interface.
+
+Example:
+```python
+
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+
+from charms.sdcore_amf.v0.fiveg_n2 import N2Provides
+
+
+class DummyFivegN2ProviderCharm(CharmBase):
+
+    HOST = "amf"
+    PORT = 38412
+    IP_ADDRESS = "192.168.70.132"
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.n2_provider = N2Provides(self, "fiveg-n2")
+        self.framework.observe(
+            self.on.fiveg_n2_relation_joined, self._on_fiveg_n2_relation_joined
+        )
+
+    def _on_fiveg_n2_relation_joined(self, event: RelationJoinedEvent):
+        if self.unit.is_leader():
+            self.n2_provider.set_n2_information(
+                amf_ip_address=self.IP_ADDRESS,
+                amf_hostname=self.HOST,
+                amf_port=self.PORT,
+            )
+
+
+if __name__ == "__main__":
+    main(DummyFivegN2ProviderCharm)
+```
+
+"""
+
+import logging
+from typing import Dict, Optional
+
+from interface_tester.schema_base import DataBagSchema  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationChangedEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+from ops.model import Relation
+from pydantic import BaseModel, Field, IPvAnyAddress, ValidationError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "3bb439930da24fd09631af74f70ea394"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft push-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+logger = logging.getLogger(__name__)
+"""Schemas definition for the provider and requirer sides of the `fiveg_n2` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "amf_ip_address": "192.168.70.132"
+            "amf_hostname": "amf",
+            "amf_port": 38412
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+
+class ProviderAppData(BaseModel):
+    """Provider app data for fiveg_n2."""
+
+    amf_ip_address: IPvAnyAddress = Field(
+        description="IP Address to reach the AMF's N2 interface.", examples=["192.168.70.132"]
+    )
+    amf_hostname: str = Field(
+        description="Hostname to reach the AMF's N2 interface.", examples=["amf"]
+    )
+    amf_port: int = Field(description="Port to reach the AMF's N2 interface.", examples=[38412])
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for fiveg_n2."""
+
+    app: ProviderAppData
+
+
+def data_is_valid(data: dict) -> bool:
+    """Returns whether data is valid.
+
+    Args:
+        data (dict): Data to be validated.
+
+    Returns:
+        bool: True if data is valid, False otherwise.
+    """
+    try:
+        ProviderSchema(app=data)
+        return True
+    except ValidationError as e:
+        logger.error("Invalid data: %s", e)
+        return False
+
+
+class N2InformationAvailableEvent(EventBase):
+    """Charm event emitted when N2 information is available. It carries the AMF hostname."""
+
+    def __init__(self, handle: Handle, amf_ip_address: str, amf_hostname: str, amf_port: int):
+        """Init."""
+        super().__init__(handle)
+        self.amf_ip_address = amf_ip_address
+        self.amf_hostname = amf_hostname
+        self.amf_port = amf_port
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "amf_ip_address": self.amf_ip_address,
+            "amf_hostname": self.amf_hostname,
+            "amf_port": self.amf_port,
+        }
+
+    def restore(self, snapshot: dict) -> None:
+        """Restores snapshot."""
+        self.amf_ip_address = snapshot["amf_ip_address"]
+        self.amf_hostname = snapshot["amf_hostname"]
+        self.amf_port = snapshot["amf_port"]
+
+
+class N2RequirerCharmEvents(CharmEvents):
+    """List of events that the N2 requirer charm can leverage."""
+
+    n2_information_available = EventSource(N2InformationAvailableEvent)
+
+
+class N2Requires(Object):
+    """Class to be instantiated by the N2 requirer charm."""
+
+    on = N2RequirerCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Init."""
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handler triggered on relation changed event.
+
+        Args:
+            event (RelationChangedEvent): Juju event.
+
+        Returns:
+            None
+        """
+        if remote_app_relation_data := self._get_remote_app_relation_data(event.relation):
+            self.on.n2_information_available.emit(
+                amf_ip_address=remote_app_relation_data["amf_ip_address"],
+                amf_hostname=remote_app_relation_data["amf_hostname"],
+                amf_port=remote_app_relation_data["amf_port"],
+            )
+
+    @property
+    def amf_ip_address(self) -> Optional[str]:
+        """Returns AMF IP address.
+
+        Returns:
+            str: AMF IP address.
+        """
+        if remote_app_relation_data := self._get_remote_app_relation_data():
+            return remote_app_relation_data.get("amf_ip_address")
+        return None
+
+    @property
+    def amf_hostname(self) -> Optional[str]:
+        """Returns AMF hostname.
+
+        Returns:
+            str: AMF hostname.
+        """
+        if remote_app_relation_data := self._get_remote_app_relation_data():
+            return remote_app_relation_data.get("amf_hostname")
+        return None
+
+    @property
+    def amf_port(self) -> Optional[int]:
+        """Returns the port used to connect to the AMF host.
+
+        Returns:
+            int: AMF port.
+        """
+        if remote_app_relation_data := self._get_remote_app_relation_data():
+            return int(remote_app_relation_data.get("amf_port"))  # type: ignore[arg-type]
+        return None
+
+    def _get_remote_app_relation_data(
+        self, relation: Optional[Relation] = None
+    ) -> Optional[Dict[str, str]]:
+        """Get relation data for the remote application.
+
+        Args:
+            Relation: Juju relation object (optional).
+
+        Returns:
+            Dict: Relation data for the remote application
+            or None if the relation data is invalid.
+        """
+        relation = relation or self.model.get_relation(self.relation_name)
+        if not relation:
+            logger.error("No relation: %s", self.relation_name)
+            return None
+        if not relation.app:
+            logger.warning("No remote application in relation: %s", self.relation_name)
+            return None
+        remote_app_relation_data = dict(relation.data[relation.app])
+        if not data_is_valid(remote_app_relation_data):
+            logger.error("Invalid relation data: %s", remote_app_relation_data)
+            return None
+        return remote_app_relation_data
+
+
+class N2Provides(Object):
+    """Class to be instantiated by the charm providing the N2 data."""
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Init."""
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+        self.charm = charm
+
+    def set_n2_information(self, amf_ip_address: str, amf_hostname: str, amf_port: int) -> None:
+        """Sets the hostname and the ngapp port in the application relation data.
+
+        Args:
+            amf_ip_address (str): AMF IP address.
+            amf_hostname (str): AMF hostname.
+            amf_port (int): AMF NGAPP port.
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            raise RuntimeError("Unit must be leader to set application relation data.")
+        relations = self.model.relations[self.relation_name]
+        if not relations:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+        if not data_is_valid(
+            {"amf_ip_address": amf_ip_address, "amf_hostname": amf_hostname, "amf_port": amf_port}
+        ):
+            raise ValueError("Invalid relation data")
+        for relation in relations:
+            relation.data[self.charm.app].update(
+                {
+                    "amf_ip_address": amf_ip_address,
+                    "amf_hostname": amf_hostname,
+                    "amf_port": str(amf_port),
+                }
+            )

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,5 +23,9 @@ storage:
     type: filesystem
     minimum-size: 1M
 
+requires:
+  fiveg-n2:
+    interface: fiveg_n2
+
 assumes:
   - k8s-api

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ jinja2
 lightkube
 lightkube-models
 ops
+pydantic
+pytest-interface-tester

--- a/src/charm.py
+++ b/src/charm.py
@@ -83,6 +83,9 @@ class GNBSIMOperatorCharm(CharmBase):
         if invalid_configs := self._get_invalid_configs():
             self.unit.status = BlockedStatus(f"Configurations are invalid: {invalid_configs}")
             return
+        if not self._relation_created(N2_RELATION_NAME):
+            self.unit.status = BlockedStatus("Waiting for N2 relation to be created")
+            return
         if not self._container.can_connect():
             self.unit.status = WaitingStatus("Waiting for container to be ready")
             event.defer()
@@ -95,9 +98,7 @@ class GNBSIMOperatorCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting for Multus to be ready")
             event.defer()
             return
-        if not self._relation_created(N2_RELATION_NAME):
-            self.unit.status = BlockedStatus("Waiting for N2 relation to be created")
-            return
+
         if not self._n2_requirer.amf_hostname or not self._n2_requirer.amf_port:
             self.unit.status = WaitingStatus("Waiting for N2 information")
             return

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
+AMF_CHARM_NAME = "sdcore-amf"
 
 
 @pytest.fixture(scope="module")
@@ -29,13 +30,32 @@ async def build_and_deploy(ops_test):
         application_name=APP_NAME,
         trust=True,
     )
+    await ops_test.model.deploy(
+        AMF_CHARM_NAME,
+        application_name=AMF_CHARM_NAME,
+        channel="edge",
+        trust=True,
+    )
 
 
 @pytest.mark.abort_on_fail
-async def test_given_charm_is_built_when_deployed_then_status_is_active(
+async def test_deploy_charm_and_wait_for_blocked_status(
     ops_test,
     build_and_deploy,
 ):
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="blocked",
+        timeout=1000,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_relate_and_wait_for_active_status(
+    ops_test,
+    build_and_deploy,
+):
+    await ops_test.model.add_relation(relation1=f"{APP_NAME}:fiveg-n2", relation2=AMF_CHARM_NAME)
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
         raise_on_error=False,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -76,6 +76,7 @@ class TestCharm(unittest.TestCase):
     def test_given_cant_connect_to_workload_when_config_changed_then_status_is_waiting(
         self,
     ):
+        self._create_n2_relation()
         self.harness.set_can_connect(container="gnbsim", val=False)
 
         self.harness.update_config(key_values={})
@@ -92,6 +93,7 @@ class TestCharm(unittest.TestCase):
     ):
         patch_exists.return_value = False
         self.harness.set_can_connect(container="gnbsim", val=True)
+        self._create_n2_relation()
 
         self.harness.update_config(key_values={})
 
@@ -110,6 +112,7 @@ class TestCharm(unittest.TestCase):
         patch_exists.return_value = True
         patch_is_ready.return_value = False
         self.harness.set_can_connect(container="gnbsim", val=True)
+        self._create_n2_relation()
 
         self.harness.update_config(key_values={})
 
@@ -118,20 +121,9 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for Multus to be ready"),
         )
 
-    @patch("ops.model.Container.push")
-    @patch(f"{MULTUS_LIB_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch("ops.model.Container.exec", new=Mock)
-    @patch("ops.model.Container.exists")
     def test_given_n2_relation_not_created_when_config_changed_then_status_is_blocked(
         self,
-        patch_dir_exists,
-        patch_is_ready,
-        patch_push,
     ):
-        patch_is_ready.return_value = True
-        patch_dir_exists.return_value = True
-        self.harness.set_can_connect(container="gnbsim", val=True)
-
         self.harness.update_config(key_values={})
 
         self.assertEqual(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, patch
 
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
@@ -39,6 +39,29 @@ class TestCharm(unittest.TestCase):
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+
+    def _create_n2_relation(self) -> int:
+        """Creates a relation between gnbsim and amf.
+
+        Returns:
+            int: Id of the created relation
+        """
+        amf_relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="amf")
+        self.harness.add_relation_unit(relation_id=amf_relation_id, remote_unit_name="amf/0")
+        return amf_relation_id
+
+    def _n2_data_available(self) -> None:
+        """Creates the N2 relation and sets the relation data in the n2 relation."""
+        amf_relation_id = self._create_n2_relation()
+        self.harness.update_relation_data(
+            relation_id=amf_relation_id,
+            app_or_unit="amf",
+            key_values={
+                "amf_hostname": "amf",
+                "amf_port": "38412",
+                "amf_ip_address": "1.1.1.1",
+            },
+        )
 
     def test_given_default_config_when_config_changed_then_status_is_blocked(
         self,
@@ -99,7 +122,7 @@ class TestCharm(unittest.TestCase):
     @patch(f"{MULTUS_LIB_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch("ops.model.Container.exec", new=Mock)
     @patch("ops.model.Container.exists")
-    def test_given_n2_information_not_available_when_config_changed_then_status_is_waiting(
+    def test_given_n2_relation_not_created_when_config_changed_then_status_is_blocked(
         self,
         patch_dir_exists,
         patch_is_ready,
@@ -113,11 +136,31 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.charm.unit.status,
+            BlockedStatus("Waiting for N2 relation to be created"),
+        )
+
+    @patch("ops.model.Container.push")
+    @patch(f"{MULTUS_LIB_PATH}.KubernetesMultusCharmLib.is_ready")
+    @patch("ops.model.Container.exec", new=Mock)
+    @patch("ops.model.Container.exists")
+    def test_given_n2_information_not_available_when_config_changed_then_status_is_waiting(
+        self,
+        patch_dir_exists,
+        patch_is_ready,
+        patch_push,
+    ):
+        patch_is_ready.return_value = True
+        patch_dir_exists.return_value = True
+        self.harness.set_can_connect(container="gnbsim", val=True)
+        self._create_n2_relation()
+
+        self.harness.update_config(key_values={})
+
+        self.assertEqual(
+            self.harness.charm.unit.status,
             WaitingStatus("Waiting for N2 information"),
         )
 
-    @patch("charms.sdcore_amf.v0.fiveg_n2.N2Requires.amf_hostname", new_callable=PropertyMock)
-    @patch("charms.sdcore_amf.v0.fiveg_n2.N2Requires.amf_port", new_callable=PropertyMock)
     @patch("ops.model.Container.push")
     @patch(f"{MULTUS_LIB_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch("ops.model.Container.exec", new=Mock)
@@ -127,14 +170,12 @@ class TestCharm(unittest.TestCase):
         patch_dir_exists,
         patch_is_ready,
         patch_push,
-        patch_amf_port,
-        patch_amf_hostname,
     ):
-        patch_amf_port.return_value = 38412
-        patch_amf_hostname.return_value = "amf"
         patch_is_ready.return_value = True
         patch_dir_exists.return_value = True
         self.harness.set_can_connect(container="gnbsim", val=True)
+
+        self._n2_data_available()
 
         self.harness.update_config(key_values={})
 
@@ -147,7 +188,7 @@ class TestCharm(unittest.TestCase):
     @patch(f"{MULTUS_LIB_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch("ops.model.Container.exec", new=Mock)
     @patch("ops.model.Container.exists")
-    def test_given_default_config_when_n2_relation_joined_then_config_is_written_to_workload(
+    def test_given_default_config_and_n2_info_available_when_n2_relation_joined_then_config_is_written_to_workload(  # noqa: E501
         self,
         patch_dir_exists,
         patch_is_ready,
@@ -157,25 +198,13 @@ class TestCharm(unittest.TestCase):
         patch_dir_exists.return_value = True
         self.harness.set_can_connect(container="gnbsim", val=True)
 
-        amf_relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="amf")
-        self.harness.add_relation_unit(relation_id=amf_relation_id, remote_unit_name="amf/0")
-        self.harness.update_relation_data(
-            relation_id=amf_relation_id,
-            app_or_unit="amf",
-            key_values={
-                "amf_hostname": "amf",
-                "amf_port": "38412",
-                "amf_ip_address": "1.1.1.1",
-            },
-        )
+        self._n2_data_available()
 
         expected_config_file_content = read_file("tests/unit/expected_config.yaml")
         patch_push.assert_called_with(
             source=expected_config_file_content, path="/etc/gnbsim/gnb.conf"
         )
 
-    @patch("charms.sdcore_amf.v0.fiveg_n2.N2Requires.amf_hostname", new_callable=PropertyMock)
-    @patch("charms.sdcore_amf.v0.fiveg_n2.N2Requires.amf_port", new_callable=PropertyMock)
     @patch("ops.model.Container.push", new=Mock)
     @patch(f"{MULTUS_LIB_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch("ops.model.Container.exec", new=Mock)
@@ -184,21 +213,17 @@ class TestCharm(unittest.TestCase):
         self,
         patch_dir_exists,
         patch_is_ready,
-        patch_amf_port,
-        patch_amf_hostname,
     ):
-        patch_amf_port.return_value = 38412
-        patch_amf_hostname.return_value = "amf"
         patch_is_ready.return_value = True
         patch_dir_exists.return_value = True
         self.harness.set_can_connect(container="gnbsim", val=True)
+
+        self._n2_data_available()
 
         self.harness.update_config(key_values={})
 
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
 
-    @patch("charms.sdcore_amf.v0.fiveg_n2.N2Requires.amf_hostname", new_callable=PropertyMock)
-    @patch("charms.sdcore_amf.v0.fiveg_n2.N2Requires.amf_port", new_callable=PropertyMock)
     @patch("ops.model.Container.push", new=Mock)
     @patch(f"{MULTUS_LIB_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch("ops.model.Container.exec")
@@ -208,16 +233,14 @@ class TestCharm(unittest.TestCase):
         patch_dir_exists,
         patch_exec,
         patch_is_ready,
-        patch_amf_port,
-        patch_amf_hostname,
     ):
-        patch_amf_port.return_value = 38412
-        patch_amf_hostname.return_value = "amf"
         upf_ip_address = "1.1.1.1"
         upf_gateway = "2.2.2.2"
         patch_is_ready.return_value = True
         patch_dir_exists.return_value = True
         self.harness.set_can_connect(container="gnbsim", val=True)
+
+        self._n2_data_available()
 
         self.harness.update_config(
             key_values={


### PR DESCRIPTION
Implements the requirer side of the n2 relation interface:
- Removes `amf_hostname` and `amf_port` from config as they will be retrieved from relation data.
- Adds the relation as a required relation
- Adds unit tests
- Adds dependencies

# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library