### PR TITLE
[Feat] Uses ROCK instead of upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ juju run sdcore-gnbsim/leader start-simulation
 
 ## Image
 
-- **gnbsim**: `omecproject/5gc-gnbsim:main-1caccfc`
+- **gnbsim**: `ghcr.io/canonical/sdcore-gnbsim:1.3`

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   gnbsim-image:
     type: oci-image
     description: OCI image for 5G gnbsim
-    upstream-source: omecproject/5gc-gnbsim:main-1caccfc
+    upstream-source: ghcr.io/canonical/sdcore-gnbsim:1.3
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -133,7 +133,7 @@ class GNBSIMOperatorCharm(CharmBase):
             return
         try:
             stdout, stderr = self._exec_command_in_workload(
-                command=f"/gnbsim/bin/gnbsim --cfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
+                command=f"/bin/gnbsim --cfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
             )
             if not stderr:
                 event.fail(message="No output in simulation")
@@ -316,18 +316,15 @@ class GNBSIMOperatorCharm(CharmBase):
     def _exec_command_in_workload(
         self,
         command: str,
-        environment: Optional[dict] = None,
     ) -> Tuple[Optional[str], Optional[str]]:
         """Executes command in workload container.
 
         Args:
             command: Command to execute
-            environment: Environment Variables
         """
         process = self._container.exec(
             command=command.split(),
             timeout=30,
-            environment=environment,
         )
         return process.wait_output()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -244,7 +244,6 @@ class TestCharm(unittest.TestCase):
         patch_exec.assert_called_with(
             command=["ip", "route", "replace", upf_ip_address, "via", upf_gateway],
             timeout=30,
-            environment=None,
         )
 
     def test_given_cant_connect_to_workload_when_start_simulation_action_then_event_fails(self):
@@ -334,7 +333,25 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.exec")
     @patch("ops.model.Container.exists")
-    def test_given_simulation_succeeds_swhen_start_simulation_action_then_simulation_result_is_true(  # noqa: E501
+    def test_given_can_connect_to_workload_when_start_simulation_action_then_simulation_is_started(
+        self, patch_exists, patch_exec
+    ):
+        event = Mock()
+        patch_exists.return_value = True
+        patch_process = Mock()
+        patch_exec.return_value = patch_process
+        patch_process.wait_output.return_value = ("Whatever stdout", "Whatever stderr")
+        self.harness.set_can_connect(container="gnbsim", val=True)
+
+        self.harness.charm._on_start_simulation_action(event=event)
+
+        patch_exec.assert_any_call(
+            command=["/bin/gnbsim", "--cfg", "/etc/gnbsim/gnb.conf"], timeout=30
+        )
+
+    @patch("ops.model.Container.exec")
+    @patch("ops.model.Container.exists")
+    def test_given_simulation_succeeds_when_start_simulation_action_then_simulation_result_is_true(
         self, patch_exists, patch_exec
     ):
         event = Mock()


### PR DESCRIPTION
# Description

Uses ROCK instead of upstream image. Depends on:
- https://github.com/canonical/sdcore-gnbsim-rock/pull/1

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library