### PR TITLE
Increase action execution timeout for integration tests

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -324,7 +324,7 @@ class GNBSIMOperatorCharm(CharmBase):
         """
         process = self._container.exec(
             command=command.split(),
-            timeout=30,
+            timeout=300,
         )
         return process.wait_output()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -243,7 +243,7 @@ class TestCharm(unittest.TestCase):
 
         patch_exec.assert_called_with(
             command=["ip", "route", "replace", upf_ip_address, "via", upf_gateway],
-            timeout=30,
+            timeout=300,
         )
 
     def test_given_cant_connect_to_workload_when_start_simulation_action_then_event_fails(self):
@@ -346,7 +346,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_start_simulation_action(event=event)
 
         patch_exec.assert_any_call(
-            command=["/bin/gnbsim", "--cfg", "/etc/gnbsim/gnb.conf"], timeout=30
+            command=["/bin/gnbsim", "--cfg", "/etc/gnbsim/gnb.conf"], timeout=300
         )
 
     @patch("ops.model.Container.exec")


### PR DESCRIPTION
# Description

The integration tests sometimes fail with a `context deadline exceeeded` after 30 seconds. On GitHub runners, resources are limited and it can take longer to execute.

This increases the timeout value to 5 minutes.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library