### PR TITLE
Add support for specifying underlying host interface to use for RAN network

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ options:
     description: gNodeB IP Address
   gnb-interface:
     type: string
-    description: Host interface to use for the RAN Network.
+    description: Host interface to use for the RAN Network. If unspecificed, a bridge will be used.
   icmp-packet-destination:
     type: string
     default: "192.168.250.1"

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,9 @@ options:
     type: string
     default: "192.168.251.5/24"
     description: gNodeB IP Address
+  gnb-interface:
+    type: string
+    description: Host interface to use for the RAN Network.
   icmp-packet-destination:
     type: string
     default: "192.168.250.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ jinja2
 lightkube
 lightkube-models
 ops
-pydantic
+pydantic==2.0.2
 pytest-interface-tester
+PyYAML>=6.0.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
-juju==3.2.0.0
+git+https://github.com/juju/python-libjuju
 mypy
 pep8-naming
 pyproject-flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
-git+https://github.com/juju/python-libjuju
+juju==3.2.0.1
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,5 +1,5 @@
-# copyright 2023 canonical ltd.
-# see license file for licensing details.
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
 
 import json
 import unittest

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,6 +1,7 @@
-# Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
+# copyright 2023 canonical ltd.
+# see license file for licensing details.
 
+import json
 import unittest
 from unittest.mock import Mock, patch
 
@@ -366,3 +367,33 @@ class TestCharm(unittest.TestCase):
         event.set_results.assert_called_with(
             {"success": "true", "info": "run juju debug-log to get more information."}
         )
+
+    def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_specified_in_nad(  # noqa: E501
+        self,
+    ):
+        self.harness.disable_hooks()
+        self.harness.update_config(
+            key_values={
+                "gnb-ip-address": "192.168.251.5",
+            }
+        )
+        nad = self.harness.charm._network_attachment_definition_from_config()
+        config = json.loads(nad["config"])
+        self.assertNotIn("master", config)
+        self.assertEqual("bridge", config["type"])
+        self.assertEqual(config["bridge"], "ran-br")
+
+    def test_given_default_config_with_interfaces_when_network_attachment_definitions_from_config_is_called_then_interfaces_specified_in_nad(  # noqa: E501
+        self,
+    ):
+        self.harness.disable_hooks()
+        self.harness.update_config(
+            key_values={
+                "gnb-ip-address": "192.168.251.5",
+                "gnb-interface": "gnb",
+            }
+        )
+        nad = self.harness.charm._network_attachment_definition_from_config()
+        config = json.loads(nad["config"])
+        self.assertEqual(config["master"], "gnb")
+        self.assertEqual(config["type"], "macvlan")


### PR DESCRIPTION
# Description

By default, a `macvlan` interface will use the underlying host's interface with the default gateway. When following the tutorial, all interfaces share the same underlying host's interface.

However, it prevents connectivity with the outside world for real world scenario, like connecting a real `gNodeB`, or deploying the `UPF` on the edge, away from the core.

This change allows specifying what host interface to use for each multus interfaces, allowing the operator to expose the `UPF` to external networks.

When not specifying interfaces, `multus` interfaces will be created with the `bridge` plugin, separating the network traffic in different networks.


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library