### PR TITLE
(Fix) Downgrading version of ops library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jinja2
 lightkube
 lightkube-models
-ops
+ops==2.4.1
 pydantic==2.0.2
 pytest-interface-tester
 PyYAML>=6.0.1


### PR DESCRIPTION
# Description

Latest `ops` is incompatible with `scenario`. This PR downgrades `ops` version to the latest working one (2.4.1).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library