### PR TITLE
Adding fiveg_gnb_identity relation interface

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,3 +41,27 @@ jobs:
     with:
       charm-file-name: "sdcore-gnbsim_ubuntu-22.04-amd64.charm"
     secrets: inherit
+
+  fiveg-gnb-identity-lib-needs-publishing:
+    runs-on: ubuntu-22.04
+    outputs:
+      needs-publishing: ${{ steps.changes.outputs.fiveg_gnb_identity }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            fiveg_gnb_identity:
+              - 'lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py'
+
+  publish-fiveg-gnb-identity-lib:
+    name: Publish Lib
+    needs:
+      - publish-charm
+      - fiveg-gnb-identity-lib-needs-publishing
+    if: ${{ github.ref_name == 'main' }}
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@main
+    with:
+      lib-name: "charms.sdcore_gnbsim.v0.fiveg_gnb_identity"
+    secrets: inherit

--- a/lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py
+++ b/lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py
@@ -91,7 +91,7 @@ from ops.framework import EventBase, EventSource, Object
 from pydantic import BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "bc6261cf77104d4fb3edfd6d4ea63149" # HOW DO I GENERATE IT
+LIBID = "ca9a66c5806e47e7b2750e8cdf696b80"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0

--- a/lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py
+++ b/lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py
@@ -115,7 +115,7 @@ Examples:
         unit: <empty>
         app: {
             "gnb_name": "gnb001",
-            "tac": "1"
+            "tac": "00001"
         }
     RequirerSchema:
         unit: <empty>
@@ -130,9 +130,9 @@ class FivegGnbIdentityProviderAppData(BaseModel):
         description="Name of the gnB.",
         examples=["gnb001"]
     )
-    tac: int = Field(
+    tac: str = Field(
         description="Tracking Area Code",
-        examples=[1]
+        examples=["00001"]
     )
 
 class ProviderSchema(DataBagSchema):
@@ -201,14 +201,14 @@ class GnbIdentityProvides(Object):
         self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_joined)
 
     def publish_gnb_identity_information(
-        self, relation_id: int, gnb_name: str, tac: int
+        self, relation_id: int, gnb_name: str, tac: str
     ) -> None:
         """Sets gNodeB's name and TAC in the relation data.
 
         Args:
             relation_id (str): Relation ID
             gnb_name (str): name of the gNodeB.
-            tac (int): Tracking Area Code.
+            tac (str): Tracking Area Code.
         """
         if not data_matches_provider_schema(
             data={"gnb_name": gnb_name, "tac": tac}
@@ -220,7 +220,7 @@ class GnbIdentityProvides(Object):
         if not relation:
             raise RuntimeError(f"Relation {self.relation_name} not created yet.")
         relation.data[self.charm.app]["gnb_name"] = gnb_name
-        relation.data[self.charm.app]["tac"] = str(tac)
+        relation.data[self.charm.app]["tac"] = tac
 
     def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Triggered whenever a requirer charm joins the relation.
@@ -234,7 +234,7 @@ class GnbIdentityProvides(Object):
 class GnbIdentityAvailableEvent(EventBase):
     """Dataclass for the `fiveg_gnb_identity` available event."""
 
-    def __init__(self, handle, gnb_name: str, tac: int):
+    def __init__(self, handle, gnb_name: str, tac: str):
         """Sets gNodeB's name and TAC."""
         super().__init__(handle)
         self.gnb_name = gnb_name

--- a/lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py
+++ b/lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py
@@ -284,7 +284,7 @@ class GnbIdentityRequires(Object):
             event (RelationChangedEvent): Juju event
         """
         relation_data = event.relation.data
-        gnb_name = relation_data[event.unit].get("gnb_name")  # type: ignore[index]
-        tac = relation_data[event.unit].get("tac")  # type: ignore[index]
+        gnb_name = relation_data[event.app].get("gnb_name")  # type: ignore[index]
+        tac = relation_data[event.app].get("tac")  # type: ignore[index]
         if gnb_name and tac:
             self.on.fiveg_gnb_identity_available.emit(gnb_name=gnb_name, tac=tac)

--- a/lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py
+++ b/lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py
@@ -1,0 +1,290 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the `fiveg_gnb_identity` relation.
+
+This library contains the Requires and Provides classes for handling the `fiveg_gnb_identity`
+interface.
+
+The purpose of this library is to integrate a for gNodeb’s to share their identity to charms
+that require those informations. 
+
+To get started using the library, you need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.sdcore_gnbsim.v0.fiveg_gnb_identity
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- pydantic
+- pytest-interface-tester
+
+Charms providing the `fiveg_gnb_identity` relation should use `GnbIdentityProvides`.
+Typical usage of this class would look something like:
+
+    ```python
+    ...
+    from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityProvides
+    ...
+
+    class SomeProviderCharm(CharmBase):
+
+        def __init__(self, *args):
+            ...
+            self.gnb_identity_provider = GnbIdentityProvides(charm=self, relation_name="fiveg_gnb_identity")
+            ...
+            self.framework.observe(self.gnb_identity_provider.on.fiveg_gnb_identity_request, self._on_fiveg_gnb_identity_request)
+
+        def _on_fiveg_gnb_identity_request(self, event):
+            ...
+            self.gnb_identity_provider.publish_gnb_identity_information(
+                relation_id=event.relation_id,
+                gnb_name=name,
+                tac=tac,
+            )
+    ```
+
+    And a corresponding section in charm's `metadata.yaml`:
+    ```
+    provides:
+        fiveg_gnb_identity:  # Relation name
+            interface: fiveg_gnb_identity  # Relation interface
+    ```
+
+Charms that require the `fiveg_gnb_identity` relation should use `GnbIdentityRequires`.
+Typical usage of this class would look something like:
+
+    ```python
+    ...
+    from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityRequires
+    ...
+
+    class SomeRequirerCharm(CharmBase):
+
+        def __init__(self, *args):
+            ...
+            self.fiveg_gnb_identity = GnbIdentityRequires(charm=self, relation_name="fiveg_gnb_identity")
+            ...
+            self.framework.observe(self.fiveg_gnb_identity.on.fiveg_gnb_identity_available, 
+                self._on_fiveg_gnb_identity_available)
+
+        def _on_fiveg_gnb_identity_available(self, event):
+            gnb_name = event.gnb_name,
+            tac = event.tac,
+            # Do something with the gnB's name and TAC.
+    ```
+
+    And a corresponding section in charm's `metadata.yaml`:
+    ```
+    requires:
+        fiveg_gnb_identity:  # Relation name
+            interface: fiveg_gnb_identity  # Relation interface
+    ```
+"""
+
+import logging
+
+from interface_tester.schema_base import DataBagSchema  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, RelationJoinedEvent
+from ops.framework import EventBase, EventSource, Object
+from pydantic import BaseModel, Field, ValidationError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "bc6261cf77104d4fb3edfd6d4ea63149" # HOW DO I GENERATE IT
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+PYDEPS = ["pydantic", "pytest-interface-tester"]
+
+
+logger = logging.getLogger(__name__)
+
+"""Schemas definition for the provider and requirer sides of the `fiveg_gnb_identity` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "gnb_name": "gnb001",
+            "tac": "1"
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+
+class FivegGnbIdentityProviderAppData(BaseModel):
+    """Provider app data for fiveg_gnb_identity."""
+
+    gnb_name: str = Field(
+        description="Name of the gnB.",
+        examples=["gnb001"]
+    )
+    tac: int = Field(
+        description="Tracking Area Code",
+        examples=[1]
+    )
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for fiveg_gnb_identity."""
+
+    app: FivegGnbIdentityProviderAppData
+
+
+def data_matches_provider_schema(data: dict) -> bool:
+    """Returns whether data matches provider schema.
+
+    Args:
+        data (dict): Data to be validated.
+
+    Returns:
+        bool: True if data matches provider schema, False otherwise.
+    """
+    try:
+        ProviderSchema(app=data)
+        return True
+    except ValidationError as e:
+        logger.error("Invalid data: %s", e)
+        return False
+
+
+class FivegGnbIdentityRequestEvent(EventBase):
+    """Dataclass for the `fiveg_gnb_identity` request event."""
+
+    def __init__(self, handle, relation_id: int):
+        """Sets relation id."""
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Returns event data."""
+        return {
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot):
+        """Restores event data."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class GnbIdentityProviderCharmEvents(CharmEvents):
+    """Custom events for the GnbIdentityProvider."""
+
+    fiveg_gnb_identity_request = EventSource(FivegGnbIdentityRequestEvent)
+
+
+class GnbIdentityProvides(Object):
+    """Class to be instantiated by provider of the `fiveg_gnb_identity`."""
+
+    on = GnbIdentityProviderCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Observes relation joined event.
+
+        Args:
+            charm: Juju charm
+            relation_name (str): Relation name
+        """
+        self.relation_name = relation_name
+        self.charm = charm
+        super().__init__(charm, relation_name)
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_joined)
+
+    def publish_gnb_identity_information(
+        self, relation_id: int, gnb_name: str, tac: int
+    ) -> None:
+        """Sets gNodeB's name and TAC in the relation data.
+
+        Args:
+            relation_id (str): Relation ID
+            gnb_name (str): name of the gNodeB.
+            tac (int): Tracking Area Code.
+        """
+        if not data_matches_provider_schema(
+            data={"gnb_name": gnb_name, "tac": tac}
+        ):
+            raise ValueError(f"Invalid gnb identity data: {gnb_name}, {tac}")
+        relation = self.model.get_relation(
+            relation_name=self.relation_name, relation_id=relation_id
+        )
+        if not relation:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+        relation.data[self.charm.app]["gnb_name"] = gnb_name
+        relation.data[self.charm.app]["tac"] = str(tac)
+
+    def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Triggered whenever a requirer charm joins the relation.
+
+        Args:
+            event (RelationJoinedEvent): Juju event
+        """
+        self.on.fiveg_gnb_identity_request.emit(relation_id=event.relation.id)
+
+
+class GnbIdentityAvailableEvent(EventBase):
+    """Dataclass for the `fiveg_gnb_identity` available event."""
+
+    def __init__(self, handle, gnb_name: str, tac: int):
+        """Sets gNodeB's name and TAC."""
+        super().__init__(handle)
+        self.gnb_name = gnb_name
+        self.tac = tac
+
+    def snapshot(self) -> dict:
+        """Returns event data."""
+        return {
+            "gnb_name": self.gnb_name,
+            "tac": self.tac,
+        }
+
+    def restore(self, snapshot):
+        """Restores event data."""
+        self.gnb_name = snapshot["gnb_name"]
+        self.tac = snapshot["tac"]
+
+
+class GnbIdentityRequirerCharmEvents(CharmEvents):
+    """Custom events for the GnbIdentityRequirer."""
+
+    fiveg_gnb_identity_available = EventSource(GnbIdentityAvailableEvent)
+
+
+class GnbIdentityRequires(Object):
+    """Class to be instantiated by requirer of the `fiveg_gnb_identity`."""
+
+    on = GnbIdentityRequirerCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Observes relation joined and relation changed events.
+
+        Args:
+            charm: Juju charm
+            relation_name (str): Relation name
+        """
+        self.relation_name = relation_name
+        self.charm = charm
+        super().__init__(charm, relation_name)
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_changed)
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Triggered everytime there's a change in relation data.
+
+        Args:
+            event (RelationChangedEvent): Juju event
+        """
+        relation_data = event.relation.data
+        gnb_name = relation_data[event.unit].get("gnb_name")  # type: ignore[index]
+        tac = relation_data[event.unit].get("tac")  # type: ignore[index]
+        if gnb_name and tac:
+            self.on.fiveg_gnb_identity_available.emit(gnb_name=gnb_name, tac=tac)

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_provider_charm/metadata.yaml
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_provider_charm/metadata.yaml
@@ -1,0 +1,18 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: whatever-charm
+description: whatever-charm
+summary: whatever-charm
+containers:
+  whatever-container:
+    resource: whatever-image
+
+resources:
+  whatever-image:
+    type: oci-image
+    description: whatever image
+
+provides:
+  fiveg_gnb_identity:
+    interface: fiveg_gnb_identity

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_provider_charm/src/charm.py
@@ -1,0 +1,34 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityProvides
+from ops.charm import CharmBase
+from ops.main import main
+
+logger = logging.getLogger(__name__)
+
+
+class WhateverCharm(CharmBase):
+    TEST_GNB_NAME = ""
+    TEST_TAC = 0
+
+    def __init__(self, *args):
+        """Creates a new instance of this object for each event."""
+        super().__init__(*args)
+        self.gnb_identity_provider = GnbIdentityProvides(self, "fiveg_gnb_identity")
+
+        self.framework.observe(
+            self.gnb_identity_provider.on.fiveg_gnb_identity_request,
+            self._on_fiveg_gnb_identity_request,
+        )
+
+    def _on_fiveg_gnb_identity_request(self, event):
+        self.gnb_identity_provider.publish_gnb_identity_information(
+            relation_id=event.relation_id, gnb_name=self.TEST_GNB_NAME, tac=self.TEST_TAC
+        )
+
+
+if __name__ == "__main__":
+    main(WhateverCharm)

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_provider_charm/src/charm.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class WhateverCharm(CharmBase):
     TEST_GNB_NAME = ""
-    TEST_TAC = 0
+    TEST_TAC = ""
 
     def __init__(self, *args):
         """Creates a new instance of this object for each event."""

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_requirer_charm/metadata.yaml
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_requirer_charm/metadata.yaml
@@ -1,0 +1,18 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: whatever-charm
+description: whatever-charm
+summary: whatever-charm
+containers:
+  whatever-container:
+    resource: whatever-image
+
+resources:
+  whatever-image:
+    type: oci-image
+    description: whatever image
+
+requires:
+  fiveg_gnb_identity:
+    interface: fiveg_gnb_identity

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_requirer_charm/src/charm.py
@@ -1,0 +1,30 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityRequires
+from ops.charm import CharmBase
+from ops.main import main
+from ops.model import ActiveStatus
+
+logger = logging.getLogger(__name__)
+
+
+class WhateverCharm(CharmBase):
+    def __init__(self, *args):
+        """Creates a new instance of this object for each event."""
+        super().__init__(*args)
+        self.fiveg_gnb_identity = GnbIdentityRequires(self, "fiveg_gnb_identity")
+
+        self.framework.observe(
+            self.fiveg_gnb_identity.on.fiveg_gnb_identity_available,
+            self._on_fiveg_gnb_identity_available,
+        )
+
+    def _on_fiveg_gnb_identity_available(self, event):
+        self.model.unit.status = ActiveStatus()
+
+
+if __name__ == "__main__":
+    main(WhateverCharm)

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_provider.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_provider.py
@@ -24,7 +24,7 @@ class TestGnbIdentityProvides(unittest.TestCase):
         self, patched_test_tac, patched_test_gnb_name
     ):
         test_gnb_name = "gnb004"
-        test_tac = 1234
+        test_tac = "0002"
         patched_test_gnb_name.return_value = test_gnb_name
         patched_test_tac.return_value = test_tac
         relation_id = self.harness.add_relation(
@@ -36,7 +36,7 @@ class TestGnbIdentityProvides(unittest.TestCase):
             relation_id=relation_id, app_or_unit=self.harness.charm.app
         )
         self.assertEqual(test_gnb_name, relation_data["gnb_name"])
-        self.assertEqual(str(test_tac), relation_data["tac"])
+        self.assertEqual(test_tac, relation_data["tac"])
 
     @patch(f"{TEST_CHARM_PATH}.TEST_GNB_NAME", new_callable=PropertyMock)
     @patch(f"{TEST_CHARM_PATH}.TEST_TAC", new_callable=PropertyMock)
@@ -44,7 +44,7 @@ class TestGnbIdentityProvides(unittest.TestCase):
         self, patched_test_tac, patched_test_gnb_name
     ):
         test_invalid_gnb_name = None
-        test_tac = 1234
+        test_tac = "0002"
         patched_test_gnb_name.return_value = test_invalid_gnb_name
         patched_test_tac.return_value = test_tac
 
@@ -60,7 +60,7 @@ class TestGnbIdentityProvides(unittest.TestCase):
         self, patched_test_tac, patched_test_gnb_name
     ):
         test_gnb_name = "gnb005"
-        test_invalid_tac = "not_an_int"
+        test_invalid_tac = None
         patched_test_gnb_name.return_value = test_gnb_name
         patched_test_tac.return_value = test_invalid_tac
 

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_provider.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_provider.py
@@ -24,7 +24,7 @@ class TestGnbIdentityProvides(unittest.TestCase):
         self, patched_test_tac, patched_test_gnb_name
     ):
         test_gnb_name = "gnb004"
-        test_tac = "0002"
+        test_tac = 2
         patched_test_gnb_name.return_value = test_gnb_name
         patched_test_tac.return_value = test_tac
         relation_id = self.harness.add_relation(
@@ -36,7 +36,7 @@ class TestGnbIdentityProvides(unittest.TestCase):
             relation_id=relation_id, app_or_unit=self.harness.charm.app
         )
         self.assertEqual(test_gnb_name, relation_data["gnb_name"])
-        self.assertEqual(test_tac, relation_data["tac"])
+        self.assertEqual(str(test_tac), relation_data["tac"])
 
     @patch(f"{TEST_CHARM_PATH}.TEST_GNB_NAME", new_callable=PropertyMock)
     @patch(f"{TEST_CHARM_PATH}.TEST_TAC", new_callable=PropertyMock)
@@ -44,7 +44,7 @@ class TestGnbIdentityProvides(unittest.TestCase):
         self, patched_test_tac, patched_test_gnb_name
     ):
         test_invalid_gnb_name = None
-        test_tac = "0002"
+        test_tac = 2
         patched_test_gnb_name.return_value = test_invalid_gnb_name
         patched_test_tac.return_value = test_tac
 
@@ -60,7 +60,7 @@ class TestGnbIdentityProvides(unittest.TestCase):
         self, patched_test_tac, patched_test_gnb_name
     ):
         test_gnb_name = "gnb005"
-        test_invalid_tac = None
+        test_invalid_tac = "0xffffff"
         patched_test_gnb_name.return_value = test_gnb_name
         patched_test_tac.return_value = test_invalid_tac
 

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_provider.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_provider.py
@@ -1,0 +1,71 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import PropertyMock, patch
+
+from ops import testing
+from test_charms.test_provider_charm.src.charm import WhateverCharm  # type: ignore[import]
+
+TEST_CHARM_PATH = "test_charms.test_provider_charm.src.charm.WhateverCharm"
+
+
+class TestGnbIdentityProvides(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = testing.Harness(WhateverCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.relation_name = "fiveg_gnb_identity"
+        self.harness.set_leader(is_leader=True)
+
+    @patch(f"{TEST_CHARM_PATH}.TEST_GNB_NAME", new_callable=PropertyMock)
+    @patch(f"{TEST_CHARM_PATH}.TEST_TAC", new_callable=PropertyMock)
+    def test_given_fiveg_gnb_identity_relation_when_relation_created_then_gnb_name_and_tac_are_published_in_the_relation_data(  # noqa: E501
+        self, patched_test_tac, patched_test_gnb_name
+    ):
+        test_gnb_name = "gnb004"
+        test_tac = 1234
+        patched_test_gnb_name.return_value = test_gnb_name
+        patched_test_tac.return_value = test_tac
+        relation_id = self.harness.add_relation(
+            relation_name=self.relation_name, remote_app="whatever-app"
+        )
+        self.harness.add_relation_unit(relation_id, "whatever-app/0")
+
+        relation_data = self.harness.get_relation_data(
+            relation_id=relation_id, app_or_unit=self.harness.charm.app
+        )
+        self.assertEqual(test_gnb_name, relation_data["gnb_name"])
+        self.assertEqual(str(test_tac), relation_data["tac"])
+
+    @patch(f"{TEST_CHARM_PATH}.TEST_GNB_NAME", new_callable=PropertyMock)
+    @patch(f"{TEST_CHARM_PATH}.TEST_TAC", new_callable=PropertyMock)
+    def test_given_invalid_gnb_name_when_relation_created_then_value_error_is_raised(
+        self, patched_test_tac, patched_test_gnb_name
+    ):
+        test_invalid_gnb_name = None
+        test_tac = 1234
+        patched_test_gnb_name.return_value = test_invalid_gnb_name
+        patched_test_tac.return_value = test_tac
+
+        with self.assertRaises(ValueError):
+            relation_id = self.harness.add_relation(
+                relation_name=self.relation_name, remote_app="whatever-app"
+            )
+            self.harness.add_relation_unit(relation_id, "whatever-app/0")
+
+    @patch(f"{TEST_CHARM_PATH}.TEST_GNB_NAME", new_callable=PropertyMock)
+    @patch(f"{TEST_CHARM_PATH}.TEST_TAC", new_callable=PropertyMock)
+    def test_given_invalid_tac_when_relation_created_then_value_error_is_raised(
+        self, patched_test_tac, patched_test_gnb_name
+    ):
+        test_gnb_name = "gnb005"
+        test_invalid_tac = "not_an_int"
+        patched_test_gnb_name.return_value = test_gnb_name
+        patched_test_tac.return_value = test_invalid_tac
+
+        with self.assertRaises(ValueError):
+            relation_id = self.harness.add_relation(
+                relation_name=self.relation_name, remote_app="whatever-app"
+            )
+            self.harness.add_relation_unit(relation_id, "whatever-app/0")

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
@@ -7,6 +7,8 @@ from unittest.mock import call, patch
 from ops import testing
 from test_charms.test_requirer_charm.src.charm import WhateverCharm  # type: ignore[import]
 
+TEST_CHARM_PATH = "charms.sdcore_gnbsim.v0.fiveg_gnb_identity.GnbIdentityRequirerCharmEvents"
+
 
 class TestGnbIdentityRequires(unittest.TestCase):
     def setUp(self) -> None:
@@ -15,14 +17,12 @@ class TestGnbIdentityRequires(unittest.TestCase):
         self.harness.begin()
         self.relation_name = "fiveg_gnb_identity"
 
-    @patch(
-        "charms.sdcore_gnbsim.v0.fiveg_gnb_identity.GnbIdentityRequirerCharmEvents.fiveg_gnb_identity_available"
-    )
+    @patch(f"{TEST_CHARM_PATH}.fiveg_gnb_identity_available")
     def test_given_relation_with_gnb_identity_provider_when_gnb_identity_available_event_then_gnb_identity_information_is_provided(  # noqa: E501
         self, patched_gnb_identity_available_event
     ):
         test_gnb_name = "gnb0055"
-        test_tac = 1234
+        test_tac = "1234"
         relation_id = self.harness.add_relation(
             relation_name=self.relation_name, remote_app="whatever-app"
         )
@@ -31,10 +31,10 @@ class TestGnbIdentityRequires(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=relation_id,
             app_or_unit="whatever-app/0",
-            key_values={"gnb_name": test_gnb_name, "tac": str(test_tac)},
+            key_values={"gnb_name": test_gnb_name, "tac": test_tac},
         )
 
         calls = [
-            call.emit(gnb_name=test_gnb_name, tac=str(test_tac)),
+            call.emit(gnb_name=test_gnb_name, tac=test_tac),
         ]
         patched_gnb_identity_available_event.assert_has_calls(calls)

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
@@ -22,7 +22,7 @@ class TestGnbIdentityRequires(unittest.TestCase):
         self, patched_gnb_identity_available_event
     ):
         test_gnb_name = "gnb0055"
-        test_tac = "1234"
+        test_tac = 1234
         relation_id = self.harness.add_relation(
             relation_name=self.relation_name, remote_app="whatever-app"
         )
@@ -31,10 +31,10 @@ class TestGnbIdentityRequires(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=relation_id,
             app_or_unit="whatever-app",
-            key_values={"gnb_name": test_gnb_name, "tac": test_tac},
+            key_values={"gnb_name": test_gnb_name, "tac": str(test_tac)},
         )
 
         calls = [
-            call.emit(gnb_name=test_gnb_name, tac=test_tac),
+            call.emit(gnb_name=test_gnb_name, tac=str(test_tac)),
         ]
         patched_gnb_identity_available_event.assert_has_calls(calls)

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
@@ -30,7 +30,7 @@ class TestGnbIdentityRequires(unittest.TestCase):
 
         self.harness.update_relation_data(
             relation_id=relation_id,
-            app_or_unit="whatever-app/0",
+            app_or_unit="whatever-app",
             key_values={"gnb_name": test_gnb_name, "tac": test_tac},
         )
 

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import call, patch
+
+from ops import testing
+from test_charms.test_requirer_charm.src.charm import WhateverCharm  # type: ignore[import]
+
+
+class TestGnbIdentityRequires(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = testing.Harness(WhateverCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.relation_name = "fiveg_gnb_identity"
+
+    @patch(
+        "charms.sdcore_gnbsim.v0.fiveg_gnb_identity.GnbIdentityRequirerCharmEvents.fiveg_gnb_identity_available"
+    )
+    def test_given_relation_with_gnb_identity_provider_when_gnb_identity_available_event_then_gnb_identity_information_is_provided(  # noqa: E501
+        self, patched_gnb_identity_available_event
+    ):
+        test_gnb_name = "gnb0055"
+        test_tac = 1234
+        relation_id = self.harness.add_relation(
+            relation_name=self.relation_name, remote_app="whatever-app"
+        )
+        self.harness.add_relation_unit(relation_id, "whatever-app/0")
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit="whatever-app/0",
+            key_values={"gnb_name": test_gnb_name, "tac": str(test_tac)},
+        )
+
+        calls = [
+            call.emit(gnb_name=test_gnb_name, tac=str(test_tac)),
+        ]
+        patched_gnb_identity_available_event.assert_has_calls(calls)

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ description = Run static analysis checks
 setenv =
     PYTHONPATH = ""
 commands =
-    mypy {[vars]all_path} {posargs}
+    mypy {[vars]all_path} {posargs} --exclude tests/unit/lib/charms/ {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
# Description
This PR add the `fiveg_gnb_identity` relation interface.
The `fiveg_gnb_identity` is a charm relation interface for gNodeBs to share their identity to charms that require those informations. 

**Reference:**
https://docs.google.com/document/d/1s3U82GTUZFJ9mEhiHig0oAl44F0fq3eQT2PNv1uV75g/edit#heading=h.sxnjdvlz6lvq

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library