### PR TITLE
Changes UPF Address to Subnet

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,11 +46,11 @@ options:
     type: string
     default: "000001"
     description: Tracking Area Code. Hexadecimal value represented as a string.
-  upf-ip-address:
+  upf-subnet:
     type: string
-    default: "192.168.252.3"
-    description: UPF IP address
+    default: "192.168.252.0/24"
+    description: Subnet where the UPFs are located (also called Access network)
   upf-gateway:
     type: string
     default: "192.168.251.1"
-    description: Gateway to use to reach UPF
+    description: Gateway to use to reach the UPF subnet

--- a/src/charm.py
+++ b/src/charm.py
@@ -136,8 +136,6 @@ class GNBSIMOperatorCharm(CharmBase):
             usim_sequence_number=self._get_usim_sequence_number_from_config(),  # type: ignore[arg-type]  # noqa: E501
             sst=self._get_sst_from_config(),  # type: ignore[arg-type]
             tac=self._get_tac_from_config(),  # type: ignore[arg-type]
-            upf_gateway=self._get_upf_gateway_from_config(),  # type: ignore[arg-type]
-            upf_ip_address=self._get_upf_ip_address_from_config(),  # type: ignore[arg-type]
             usim_opc=self._get_usim_opc_from_config(),  # type: ignore[arg-type]
             usim_key=self._get_usim_key_from_config(),  # type: ignore[arg-type]
         )
@@ -262,8 +260,8 @@ class GNBSIMOperatorCharm(CharmBase):
     def _get_upf_gateway_from_config(self) -> Optional[str]:
         return self.model.config.get("upf-gateway")
 
-    def _get_upf_ip_address_from_config(self) -> Optional[str]:
-        return self.model.config.get("upf-ip-address")
+    def _get_upf_subnet_from_config(self) -> Optional[str]:
+        return self.model.config.get("upf-subnet")
 
     def _get_usim_key_from_config(self) -> Optional[str]:
         return self.model.config.get("usim-key")
@@ -296,8 +294,6 @@ class GNBSIMOperatorCharm(CharmBase):
         sd: str,
         sst: int,
         tac: str,
-        upf_gateway,
-        upf_ip_address,
         usim_key: str,
         usim_opc: str,
         usim_sequence_number: str,
@@ -315,8 +311,6 @@ class GNBSIMOperatorCharm(CharmBase):
             sd: Slice ID
             sst: Slice Selection Type
             tac: Tracking Area Code
-            upf_gateway: UPF Gateway
-            upf_ip_address: UPF IP address
             usim_key: USIM key
             usim_opc: USIM OPC
             usim_sequence_number: USIM sequence number
@@ -337,8 +331,6 @@ class GNBSIMOperatorCharm(CharmBase):
             sd=sd,
             sst=sst,
             tac=tac,
-            upf_gateway=upf_gateway,
-            upf_ip_address=upf_ip_address,
             usim_key=usim_key,
             usim_opc=usim_opc,
             usim_sequence_number=usim_sequence_number,
@@ -365,8 +357,8 @@ class GNBSIMOperatorCharm(CharmBase):
             invalid_configs.append("tac")
         if not self._get_upf_gateway_from_config():
             invalid_configs.append("upf-gateway")
-        if not self._get_upf_ip_address_from_config():
-            invalid_configs.append("upf-ip-address")
+        if not self._get_upf_subnet_from_config():
+            invalid_configs.append("upf-subnet")
         if not self._get_usim_key_from_config():
             invalid_configs.append("usim-key")
         if not self._get_usim_opc_from_config():
@@ -378,7 +370,7 @@ class GNBSIMOperatorCharm(CharmBase):
     def _create_upf_route(self) -> None:
         """Creates route to reach the UPF."""
         self._exec_command_in_workload(
-            command=f"ip route replace {self._get_upf_ip_address_from_config()} via {self._get_upf_gateway_from_config()}"  # noqa: E501
+            command=f"ip route replace {self._get_upf_subnet_from_config()} via {self._get_upf_gateway_from_config()}"  # noqa: E501
         )
         logger.info("UPF route created")
 

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -30,9 +30,6 @@ configuration:
     port: 5000
   httpServer:
     enable: false
-  networkTopo:
-  - upfAddr: {{ upf_ip_address }}
-    upfGw: {{ upf_gateway }}
   profiles:
   - dataPktCount: 5
     defaultAs: {{ icmp_packet_destination }}

--- a/tests/unit/expected_config.yaml
+++ b/tests/unit/expected_config.yaml
@@ -30,9 +30,6 @@ configuration:
     port: 5000
   httpServer:
     enable: false
-  networkTopo:
-  - upfAddr: 192.168.252.3
-    upfGw: 192.168.251.1
   profiles:
   - dataPktCount: 5
     defaultAs: 192.168.250.1

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -224,13 +224,13 @@ class TestCharm(unittest.TestCase):
         patch_is_ready,
     ):
         self.harness.add_storage("config", attach=True)
-        upf_ip_address = "1.1.1.1"
+        upf_subnet = "1.1.0.0/16"
         upf_gateway = "2.2.2.2"
         patch_is_ready.return_value = True
 
         ip_route_called = False
         timeout = 0
-        ip_route_cmd = ["ip", "route", "replace", upf_ip_address, "via", upf_gateway]
+        ip_route_cmd = ["ip", "route", "replace", upf_subnet, "via", upf_gateway]
 
         def ip_route_handler(args: testing.ExecArgs) -> testing.ExecResult:
             nonlocal ip_route_called
@@ -248,7 +248,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.update_config(
             key_values={
-                "upf-ip-address": upf_ip_address,
+                "upf-subnet": upf_subnet,
                 "upf-gateway": upf_gateway,
             }
         )


### PR DESCRIPTION
# Description

The gNB sim does not use the networkTopo section, instead it gets the UPF ip address from the SMF during the initial setup.  This means we can correct the route to be a subnet and have the gNB sim work with different UPFs depending on the slice

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- N/A Any dependent changes have been merged and published in downstream modules
- N/A I have bumped the version of the library