### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           filters: |
             fiveg_gnb_identity:
-              - 'lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py'
+              - 'lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py'
 
   publish-fiveg-gnb-identity-lib:
     name: Publish Lib
@@ -63,5 +63,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@main
     with:
-      lib-name: "charms.sdcore_gnbsim.v0.fiveg_gnb_identity"
+      lib-name: "charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity"
     secrets: inherit

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-with-multus.yaml@main
     with:
-      charm-file-name: "sdcore-gnbsim_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-gnbsim-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-gnbsim_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-gnbsim-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit
 
   fiveg-gnb-identity-lib-needs-publishing:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# SD-Core GNBSIM Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-gnbsim/badge.svg)](https://charmhub.io/sdcore-gnbsim)
+# SD-Core GNBSIM K8 Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-gnbsim-k8s/badge.svg)](https://charmhub.io/sdcore-gnbsim-k8s)
 
-A Charmed Operator for SD-Core's gNodeB simulator (GNBSIM) component. 
+A Charmed K8s Operator for SD-Core's gNodeB simulator (GNBSIM) component. 
 
 ## Usage
 
 ```bash
-juju deploy sdcore-gnbsim --trust --channel=edge
-juju run sdcore-gnbsim/leader start-simulation
+juju deploy sdcore-gnbsim-k8s --trust --channel=edge
+juju run sdcore-gnbsim-k8s/leader start-simulation
 ```
 
 ## Image

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core GNBSIM Operator for K8s
+# SD-Core GNBSIM Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-gnbsim-k8s/badge.svg)](https://charmhub.io/sdcore-gnbsim-k8s)
 
 A Charmed Operator for SD-Core's gNodeB simulator (GNBSIM) component for K8s. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core GNBSIM K8 Operator
+# SD-Core GNBSIM Operator for K8s
 [![CharmHub Badge](https://charmhub.io/sdcore-gnbsim-k8s/badge.svg)](https://charmhub.io/sdcore-gnbsim-k8s)
 
-A Charmed K8s Operator for SD-Core's gNodeB simulator (GNBSIM) component. 
+A Charmed Operator for SD-Core's gNodeB simulator (GNBSIM) component for K8s. 
 
 ## Usage
 

--- a/lib/charms/sdcore_amf_k8s/v0/fiveg_n2.py
+++ b/lib/charms/sdcore_amf_k8s/v0/fiveg_n2.py
@@ -14,7 +14,7 @@ to be able to provide or consume information on connectivity to the N2 plane.
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_amf.v0.fiveg_n2
+charmcraft fetch-lib charms.sdcore_amf_k8s.v0.fiveg_n2
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -30,7 +30,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_amf.v0.fiveg_n2 import N2InformationAvailableEvent, N2Requires
+from charms.sdcore_amf_k8s.v0.fiveg_n2 import N2InformationAvailableEvent, N2Requires
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_amf.v0.fiveg_n2 import N2Provides
+from charms.sdcore_amf_k8s.v0.fiveg_n2 import N2Provides
 
 
 class DummyFivegN2ProviderCharm(CharmBase):
@@ -105,12 +105,12 @@ from ops.model import Relation
 from pydantic import BaseModel, Field, IPvAnyAddress, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "3bb439930da24fd09631af74f70ea394"
+LIBID = "396917943b9b4b6989166b77c97a9fb8"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-# Increment this PATCH version before using `charmcraft push-lib` or reset
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 

--- a/lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py
+++ b/lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py
@@ -12,7 +12,7 @@ To get started using the library, you need to fetch the library using `charmcraf
 
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.sdcore_gnbsim.v0.fiveg_gnb_identity
+charmcraft fetch-lib charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -24,7 +24,7 @@ Typical usage of this class would look something like:
 
     ```python
     ...
-    from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityProvides
+    from charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity import GnbIdentityProvides
     ...
 
     class SomeProviderCharm(CharmBase):
@@ -56,7 +56,7 @@ Typical usage of this class would look something like:
 
     ```python
     ...
-    from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityRequires
+    from charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity import GnbIdentityRequires
     ...
 
     class SomeRequirerCharm(CharmBase):
@@ -65,7 +65,7 @@ Typical usage of this class would look something like:
             ...
             self.fiveg_gnb_identity = GnbIdentityRequires(charm=self, relation_name="fiveg_gnb_identity")
             ...
-            self.framework.observe(self.fiveg_gnb_identity.on.fiveg_gnb_identity_available, 
+            self.framework.observe(self.fiveg_gnb_identity.on.fiveg_gnb_identity_available,
                 self._on_fiveg_gnb_identity_available)
 
         def _on_fiveg_gnb_identity_available(self, event):
@@ -90,7 +90,7 @@ from ops.framework import EventBase, EventSource, Handle, Object
 from pydantic import BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "ca9a66c5806e47e7b2750e8cdf696b80"
+LIBID = "fdef465e3dc143cfb805ec074673a7e9"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
@@ -100,7 +100,6 @@ LIBAPI = 0
 LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
-
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +133,7 @@ class FivegGnbIdentityProviderAppData(BaseModel):
         examples=[1]
     )
 
+
 class ProviderSchema(DataBagSchema):
     """Provider schema for fiveg_gnb_identity."""
 
@@ -162,7 +162,7 @@ class FivegGnbIdentityRequestEvent(EventBase):
 
     def __init__(self, handle: Handle, relation_id: int):
         """Sets relation id.
-        
+
         Args:
             handle (Handle): Juju framework handle.
             relation_id : ID of the relation.
@@ -172,7 +172,7 @@ class FivegGnbIdentityRequestEvent(EventBase):
 
     def snapshot(self) -> dict:
         """Returns event data.
-        
+
         Returns:
             (dict): contains the relation ID.
         """
@@ -182,7 +182,7 @@ class FivegGnbIdentityRequestEvent(EventBase):
 
     def restore(self, snapshot: dict) -> None:
         """Restores event data.
-        
+
         Args:
             snapshot (dict): contains the relation ID.
         """
@@ -213,7 +213,7 @@ class GnbIdentityProvides(Object):
         self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_joined)
 
     def publish_gnb_identity_information(
-        self, relation_id: int, gnb_name: str, tac: int
+            self, relation_id: int, gnb_name: str, tac: int
     ) -> None:
         """Sets gNodeB's name and TAC in the relation data.
 
@@ -223,7 +223,7 @@ class GnbIdentityProvides(Object):
             tac (int): Tracking Area Code.
         """
         if not data_matches_provider_schema(
-            data={"gnb_name": gnb_name, "tac": tac}
+                data={"gnb_name": gnb_name, "tac": tac}
         ):
             raise ValueError(f"Invalid gnb identity data: {gnb_name}, {tac}")
         relation = self.model.get_relation(
@@ -261,7 +261,6 @@ class GnbIdentityAvailableEvent(EventBase):
 
     def restore(self, snapshot: dict) -> None:
         """Restores event data.
-        
         Args:
             snapshot (dict): contains information to be restored.
         """

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,12 +1,12 @@
-name: sdcore-gnbsim
+name: sdcore-gnbsim-k8s
 
-display-name: SD-Core 5G GNBSIM
+display-name: SD-Core 5G GNBSIM K8s
 summary: A Charmed Operator for SD-Core's GNBSIM component.
 description: |
   A Charmed Operator for SD-Core's gNodeB simulator (GNBSIM) component.
-website: https://charmhub.io/sdcore-gnbsim
-source: https://github.com/canonical/sdcore-gnbsim-operator
-issues: https://github.com/canonical/sdcore-gnbsim-operator/issues
+website: https://charmhub.io/sdcore-gnbsim-k8s
+source: https://github.com/canonical/sdcore-gnbsim-k8s-operator
+issues: https://github.com/canonical/sdcore-gnbsim-k8s-operator/issues
 
 containers:
   gnbsim:

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the 5G GNBSIM service."""
+"""Charmed K8s operator for the 5G GNBSIM service."""
 
 import json
 import logging
@@ -50,8 +50,8 @@ class KubernetesMultusCharmEvents(CharmEvents):
     nad_config_changed = EventSource(NadConfigChangedEvent)
 
 
-class GNBSIMOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the 5G GNBSIM operator."""
+class GNBSIMK8sOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the 5G GNBSIM K8s operator."""
 
     on = KubernetesMultusCharmEvents()
 
@@ -424,4 +424,4 @@ class GNBSIMOperatorCharm(CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(GNBSIMOperatorCharm)
+    main(GNBSIMK8sOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,8 +16,10 @@ from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import
 from charms.observability_libs.v1.kubernetes_service_patch import (  # type: ignore[import]
     KubernetesServicePatch,
 )
-from charms.sdcore_amf.v0.fiveg_n2 import N2Requires  # type: ignore[import]
-from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityProvides  # type: ignore[import]
+from charms.sdcore_amf_k8s.v0.fiveg_n2 import N2Requires  # type: ignore[import]
+from charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity import (  # type: ignore[import]
+    GnbIdentityProvides,
+)
 from jinja2 import Environment, FileSystemLoader
 from lightkube.models.core_v1 import ServicePort
 from lightkube.models.meta_v1 import ObjectMeta

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed K8s operator for the 5G GNBSIM service."""
+"""Charmed operator for the 5G GNBSIM service for K8s."""
 
 import json
 import logging
@@ -50,8 +50,8 @@ class KubernetesMultusCharmEvents(CharmEvents):
     nad_config_changed = EventSource(NadConfigChangedEvent)
 
 
-class GNBSIMK8sOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the 5G GNBSIM K8s operator."""
+class GNBSIMOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the 5G GNBSIM operator for K8s."""
 
     on = KubernetesMultusCharmEvents()
 
@@ -424,4 +424,4 @@ class GNBSIMK8sOperatorCharm(CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(GNBSIMK8sOperatorCharm)
+    main(GNBSIMOperatorCharm)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ flake8-docstrings
 flake8-builtins
 isort
 juju
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -13,9 +13,9 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-AMF_CHARM_NAME = "sdcore-amf"
+AMF_CHARM_NAME = "sdcore-amf-k8s"
 DB_CHARM_NAME = "mongodb-k8s"
-NRF_CHARM_NAME = "sdcore-nrf"
+NRF_CHARM_NAME = "sdcore-nrf-k8s"
 TLS_PROVIDER_CHARM_NAME = "self-signed-certificates"
 
 

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_provider_charm/src/charm.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityProvides
+from charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity import GnbIdentityProvides
 from ops.charm import CharmBase
 from ops.main import main
 

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_requirer_charm/src/charm.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityRequires
+from charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity import GnbIdentityRequires
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
@@ -7,7 +7,7 @@ from unittest.mock import call, patch
 from ops import testing
 from test_charms.test_requirer_charm.src.charm import WhateverCharm  # type: ignore[import]
 
-TEST_CHARM_PATH = "charms.sdcore_gnbsim.v0.fiveg_gnb_identity.GnbIdentityRequirerCharmEvents"
+TEST_CHARM_PATH = "charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity.GnbIdentityRequirerCharmEvents"
 
 
 class TestGnbIdentityRequires(unittest.TestCase):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import ChangeError
 
-from charm import GNBSIMK8sOperatorCharm
+from charm import GNBSIMOperatorCharm
 
 MULTUS_LIB_PATH = "charms.kubernetes_charm_libraries.v0.multus"
 GNB_IDENTITY_LIB_PATH = "charms.sdcore_gnbsim.v0.fiveg_gnb_identity"
@@ -37,7 +37,7 @@ class TestCharm(unittest.TestCase):
     )
     def setUp(self, patch_k8s_client):
         self.namespace = "whatever"
-        self.harness = testing.Harness(GNBSIMK8sOperatorCharm)
+        self.harness = testing.Harness(GNBSIMOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -12,7 +12,7 @@ from ops.pebble import ChangeError
 from charm import GNBSIMOperatorCharm
 
 MULTUS_LIB_PATH = "charms.kubernetes_charm_libraries.v0.multus"
-GNB_IDENTITY_LIB_PATH = "charms.sdcore_gnbsim.v0.fiveg_gnb_identity"
+GNB_IDENTITY_LIB_PATH = "charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity"
 
 
 def read_file(path: str) -> str:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import ChangeError
 
-from charm import GNBSIMOperatorCharm
+from charm import GNBSIMK8sOperatorCharm
 
 MULTUS_LIB_PATH = "charms.kubernetes_charm_libraries.v0.multus"
 GNB_IDENTITY_LIB_PATH = "charms.sdcore_gnbsim.v0.fiveg_gnb_identity"
@@ -37,7 +37,7 @@ class TestCharm(unittest.TestCase):
     )
     def setUp(self, patch_k8s_client):
         self.namespace = "whatever"
-        self.harness = testing.Harness(GNBSIMOperatorCharm)
+        self.harness = testing.Harness(GNBSIMK8sOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit) . 

- Create new fiveg_identity library
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library